### PR TITLE
Add lead capture and admin lead management

### DIFF
--- a/backend/controllers/leadController.js
+++ b/backend/controllers/leadController.js
@@ -1,0 +1,58 @@
+const { validationResult } = require('express-validator');
+const Lead = require('../models/Lead');
+const asyncHandler = require('../middleware/async');
+const ErrorResponse = require('../utils/errorResponse');
+
+// @desc    Create a new lead from CTA submission
+// @route   POST /api/leads
+// @access  Public
+exports.createLead = asyncHandler(async (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  const { fullName, mobileNumber, location, requirementDescription } = req.body;
+  await Lead.create({ fullName, mobileNumber, location, requirementDescription });
+
+  res.status(201).json({ success: true, message: 'Lead submitted successfully' });
+});
+
+// @desc    Get all leads
+// @route   GET /api/admin/leads
+// @access  Private (Admin)
+exports.getLeads = asyncHandler(async (req, res, next) => {
+  const leads = await Lead.find().sort({ createdAt: -1 });
+  res.status(200).json({ success: true, data: leads });
+});
+
+// @desc    Get single lead by ID
+// @route   GET /api/admin/leads/:id
+// @access  Private (Admin)
+exports.getLeadById = asyncHandler(async (req, res, next) => {
+  const lead = await Lead.findById(req.params.id);
+
+  if (!lead) {
+    return next(new ErrorResponse('Lead not found', 404));
+  }
+
+  res.status(200).json({ success: true, data: lead });
+});
+
+// @desc    Update lead details (status, notes, etc.)
+// @route   PUT /api/admin/leads/:id
+// @access  Private (Admin)
+exports.updateLead = asyncHandler(async (req, res, next) => {
+  let lead = await Lead.findById(req.params.id);
+
+  if (!lead) {
+    return next(new ErrorResponse('Lead not found', 404));
+  }
+
+  lead = await Lead.findByIdAndUpdate(req.params.id, req.body, {
+    new: true,
+    runValidators: true,
+  });
+
+  res.status(200).json({ success: true, data: lead });
+});

--- a/backend/models/Lead.js
+++ b/backend/models/Lead.js
@@ -1,0 +1,34 @@
+const mongoose = require('mongoose');
+
+const leadSchema = new mongoose.Schema(
+  {
+    fullName: {
+      type: String,
+      required: true,
+    },
+    mobileNumber: {
+      type: String,
+      required: true,
+    },
+    location: {
+      type: String,
+      required: true,
+    },
+    requirementDescription: {
+      type: String,
+      required: true,
+    },
+    status: {
+      type: String,
+      enum: ['new', 'contacted', 'converted', 'closed'],
+      default: 'new',
+    },
+    assignedTo: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Admin',
+    },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Lead', leadSchema);

--- a/backend/routes/adminLeadRoutes.js
+++ b/backend/routes/adminLeadRoutes.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const router = express.Router();
+const { getLeads, getLeadById, updateLead } = require('../controllers/leadController');
+const { adminAuth } = require('../middleware/adminAuth');
+
+router.route('/').get(adminAuth, getLeads);
+router
+  .route('/:id')
+  .get(adminAuth, getLeadById)
+  .put(adminAuth, updateLead);
+
+module.exports = router;

--- a/backend/routes/leadRoutes.js
+++ b/backend/routes/leadRoutes.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const router = express.Router();
+const { body } = require('express-validator');
+const { createLead } = require('../controllers/leadController');
+
+router.post(
+  '/',
+  [
+    body('fullName', 'Full name is required').notEmpty(),
+    body('mobileNumber', 'Mobile number is required').notEmpty(),
+    body('location', 'Location is required').notEmpty(),
+    body('requirementDescription', 'Requirement description is required').notEmpty(),
+  ],
+  createLead
+);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -15,11 +15,13 @@ const orderRoutes = require('./routes/orderRoutes');
 const storefrontRoutes = require('./routes/storefrontRoutes');
 const adminOrderRoutes = require('./routes/adminOrderRoutes');
 const searchLogRoutes = require('./routes/searchLogRoutes');
-const bulkUploadRoutes = require('./routes/bulkUploadRoutes'); 
+const bulkUploadRoutes = require('./routes/bulkUploadRoutes');
 const companyRoutes = require('./routes/companyRoutes');
 const reviewRoutes = require('./routes/reviewRoutes');
 const uploadRoutes = require('./routes/uploadRoutes'); // Your new upload routes
 const paymentRoutes = require('./routes/paymentRoutes');
+const leadRoutes = require('./routes/leadRoutes');
+const adminLeadRoutes = require('./routes/adminLeadRoutes');
 
 const app = express();
 app.use(express.json());
@@ -43,14 +45,16 @@ app.use('/api/storefront', storefrontRoutes);
 app.use('/api/orders', orderRoutes); 
 app.use('/api/reviews', reviewRoutes);
 app.use('/api/payment', paymentRoutes);
+app.use('/api/leads', leadRoutes);
 
 app.use('/api/admin', adminRoutes);
 app.use('/api/admin/users', userRoutes);
-app.use('/api/admin/dashboard', dashboardRoutes); 
+app.use('/api/admin/dashboard', dashboardRoutes);
 app.use('/api/admin/orders', adminOrderRoutes);
+app.use('/api/admin/leads', adminLeadRoutes);
 app.use('/api/logs/search', searchLogRoutes);
 companyRoutes.use('/:companyId/products/bulk-upload', bulkUploadRoutes);
-app.use('/api/admin/upload', uploadRoutes); 
+app.use('/api/admin/upload', uploadRoutes);
 
 
 const PORT = process.env.PORT || 5000;


### PR DESCRIPTION
## Summary
- add `Lead` mongoose model for CTA submissions
- implement controller and routes to create, list, fetch, and update leads
- wire up public and admin lead endpoints in server

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689e5be7f2d8832b9032ecc384a12a46