### PR TITLE
Add lead capture model, controllers, and routes

### DIFF
--- a/backend/controllers/admin/leadController.js
+++ b/backend/controllers/admin/leadController.js
@@ -1,0 +1,45 @@
+const { validationResult } = require('express-validator');
+const Lead = require('../../models/Lead');
+const asyncHandler = require('../../middleware/async');
+const ErrorResponse = require('../../utils/errorResponse');
+
+// @desc    Get all leads
+// @route   GET /api/admin/leads
+// @access  Private/Admin
+exports.getLeads = asyncHandler(async (req, res, next) => {
+    const leads = await Lead.find({}).sort({ createdAt: -1 });
+    res.status(200).json({ success: true, data: leads });
+});
+
+// @desc    Get single lead by ID
+// @route   GET /api/admin/leads/:id
+// @access  Private/Admin
+exports.getLeadById = asyncHandler(async (req, res, next) => {
+    const lead = await Lead.findById(req.params.id);
+    if (!lead) {
+        return next(new ErrorResponse('Lead not found', 404));
+    }
+    res.status(200).json({ success: true, data: lead });
+});
+
+// @desc    Update lead details/status
+// @route   PUT /api/admin/leads/:id
+// @access  Private/Admin
+exports.updateLead = asyncHandler(async (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+        return res.status(400).json({ errors: errors.array() });
+    }
+
+    const lead = await Lead.findByIdAndUpdate(req.params.id, req.body, {
+        new: true,
+        runValidators: true,
+    });
+
+    if (!lead) {
+        return next(new ErrorResponse('Lead not found', 404));
+    }
+
+    res.status(200).json({ success: true, data: lead });
+});
+

--- a/backend/controllers/leadController.js
+++ b/backend/controllers/leadController.js
@@ -1,0 +1,24 @@
+const { validationResult } = require('express-validator');
+const Lead = require('../models/Lead');
+const asyncHandler = require('../middleware/async');
+
+// @desc    Create a new lead from public CTA
+// @route   POST /api/leads
+// @access  Public
+exports.createLead = asyncHandler(async (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+        return res.status(400).json({ errors: errors.array() });
+    }
+
+    const { fullName, mobileNumber, location, requirementDescription } = req.body;
+    const lead = await Lead.create({
+        fullName,
+        mobileNumber,
+        location,
+        requirementDescription,
+    });
+
+    res.status(201).json({ success: true, message: 'Lead submitted successfully', data: lead });
+});
+

--- a/backend/models/Lead.js
+++ b/backend/models/Lead.js
@@ -1,0 +1,38 @@
+const mongoose = require('mongoose');
+
+const LeadSchema = new mongoose.Schema({
+    fullName: {
+        type: String,
+        required: true,
+        trim: true,
+    },
+    mobileNumber: {
+        type: String,
+        required: true,
+        trim: true,
+    },
+    location: {
+        type: String,
+        trim: true,
+    },
+    requirementDescription: {
+        type: String,
+        trim: true,
+    },
+    status: {
+        type: String,
+        enum: ['new', 'contacted', 'in_progress', 'closed'],
+        default: 'new',
+    },
+    assignedTo: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Admin',
+        default: null,
+    },
+    notes: {
+        type: String,
+        trim: true,
+    }
+}, { timestamps: true });
+
+module.exports = mongoose.model('Lead', LeadSchema);

--- a/backend/routes/adminLeadRoutes.js
+++ b/backend/routes/adminLeadRoutes.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+const { getLeads, getLeadById, updateLead } = require('../controllers/admin/leadController');
+const { adminAuth } = require('../middleware/adminAuth');
+const { body } = require('express-validator');
+
+router.use(adminAuth);
+
+router.route('/')
+    .get(getLeads);
+
+router.route('/:id')
+    .get(getLeadById)
+    .put([
+        body('status').optional().isIn(['new', 'contacted', 'in_progress', 'closed']),
+        body('assignedTo').optional().isMongoId(),
+        body('notes').optional().trim(),
+    ], updateLead);
+
+module.exports = router;

--- a/backend/routes/leadRoutes.js
+++ b/backend/routes/leadRoutes.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const router = express.Router();
+const { createLead } = require('../controllers/leadController');
+const { body } = require('express-validator');
+
+router.post('/', [
+    body('fullName', 'Full name is required').notEmpty(),
+    body('mobileNumber', 'Mobile number is required').notEmpty(),
+    body('requirementDescription', 'Requirement description is required').notEmpty(),
+], createLead);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -4,23 +4,25 @@ const express = require('express');
 const mongoose = require('mongoose');
 const path = require('path'); // Node.js module for working with file paths
 const cors = require('cors');
-const connectDB = require('./config/db'); 
+const connectDB = require('./config/db');
 
 
 const authRoutes = require('./auth/auth.routes');
 const adminRoutes = require('./routes/AdminRoutes');
 const userRoutes = require('./routes/userAdminRoutes');
 const dashboardRoutes = require('./routes/dashboardRoutes')
-const orderRoutes = require('./routes/orderRoutes'); 
+const orderRoutes = require('./routes/orderRoutes');
 const storefrontRoutes = require('./routes/storefrontRoutes');
 const adminOrderRoutes = require('./routes/adminOrderRoutes');
 const searchLogRoutes = require('./routes/searchLogRoutes');
-const bulkUploadRoutes = require('./routes/bulkUploadRoutes'); 
+const bulkUploadRoutes = require('./routes/bulkUploadRoutes');
 const companyRoutes = require('./routes/companyRoutes');
 const reviewRoutes = require('./routes/reviewRoutes');
 const uploadRoutes = require('./routes/uploadRoutes'); // Your new upload routes
 const paymentRoutes = require('./routes/paymentRoutes');
-const advertisementRoutes = require('./routes/advertisementRoutes'); 
+const advertisementRoutes = require('./routes/advertisementRoutes');
+const leadRoutes = require('./routes/leadRoutes');
+const adminLeadRoutes = require('./routes/adminLeadRoutes');
 // const companyRoutes = require('./routes/companyRoutes');
 
 const app = express();
@@ -28,7 +30,7 @@ app.use(express.json());
 const corsOptions = {
     origin: [
         'http://localhost:3000', // For your local development
-        'http://localhost:3001', 
+        'http://localhost:3001',
         'https://buildora-git-v1-mvp-manu2954s-projects.vercel.app',
         'https://www.buildoraenterprise.com'
     ],
@@ -43,20 +45,22 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use('/api/v1/upload', require('./routes/uploadRoutes'));
 app.use('/api/auth', authRoutes);
-app.use('/api/storefront', storefrontRoutes); 
-app.use('/api/orders', orderRoutes); 
+app.use('/api/storefront', storefrontRoutes);
+app.use('/api/orders', orderRoutes);
 app.use('/api/reviews', reviewRoutes);
 app.use('/api/payment', paymentRoutes);
+app.use('/api/leads', leadRoutes);
 
 app.use('/api/admin', adminRoutes);
 app.use('/api/admin/users', userRoutes);
-app.use('/api/admin/dashboard', dashboardRoutes); 
+app.use('/api/admin/dashboard', dashboardRoutes);
 app.use('/api/admin/orders', adminOrderRoutes);
 app.use('/api/logs/search', searchLogRoutes);
 // companyRoutes.use('/:companyId/products/bulk-upload', bulkUploadRoutes);
 app.use('/api/admin/companies', companyRoutes);
-app.use('/api/admin/upload', uploadRoutes); 
+app.use('/api/admin/upload', uploadRoutes);
 app.use('/api/admin/advertisements', advertisementRoutes);
+app.use('/api/admin/leads', adminLeadRoutes);
 
 const PORT = process.env.PORT || 5000;
 


### PR DESCRIPTION
## Summary
- add `Lead` mongoose model for capturing CTA submissions with status and assignment fields
- implement public lead creation and admin-side lead management controllers
- expose new `/api/leads` and `/api/admin/leads` routes and wire them in server

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689e68b37904832b8dbbffa1529855b9