### PR TITLE
feat(admin): add leads management frontend

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -50,6 +50,8 @@ import Products from './pages/admin/products/AllProductsPage';
 import ImageLibraryPage from './pages/admin/products/ImageLibraryPage';
 import { SiteProvider } from './context/SiteContext';
 import AdManagementPage from './pages/admin/AdManagementPage';
+import LeadListPage from './pages/admin/lead/LeadListPage';
+import ViewLeadPage from './pages/admin/lead/ViewLeadPage';
 
 
 function App() {
@@ -104,8 +106,10 @@ function App() {
                                 <Route path="orders/:orderId" element={<AdminOrderDetailPage />} />
                                 <Route path="bulk-upload" element={<BulkUploadPage />} />
                                 <Route path="products" element={<Products />} />
-                                <Route path="image-library" element={<ImageLibraryPage />} /> 
+                                <Route path="image-library" element={<ImageLibraryPage />} />
                                 <Route path="advertisements" element={<AdManagementPage />} /> {/* New Route */}
+                                <Route path="leads" element={<LeadListPage />} />
+                                <Route path="leads/:leadId" element={<ViewLeadPage />} />
 
                             </Route>
 

--- a/frontend/src/components/admin/AdminSidebar.jsx
+++ b/frontend/src/components/admin/AdminSidebar.jsx
@@ -60,7 +60,7 @@
 
 import React from 'react';
 import { NavLink } from 'react-router-dom';
-import { LayoutDashboard, Users, Building, ShoppingBag, Upload, Image, Megaphone } from 'lucide-react';
+import { LayoutDashboard, Users, Building, ShoppingBag, Upload, Image, Megaphone, PhoneCall } from 'lucide-react';
 
 const AdminSidebar = ({ isOpen, toggleSidebar }) => {
     const commonLinkClasses = "flex items-center px-4 py-3 text-gray-700 rounded-lg hover:bg-indigo-100 hover:text-indigo-700 transition-colors duration-150";
@@ -75,6 +75,7 @@ const AdminSidebar = ({ isOpen, toggleSidebar }) => {
         { to: "/admin/image-library", icon: <Image size={20} />, label: "Image Library" }, // New Link
         { to: "/admin/orders", icon: <ShoppingBag size={20} />, label: "Orders" },
         { to: "/admin/advertisements", icon: <Megaphone size={20} />, label: "Ads Management" }, // New Link
+        { to: "/admin/leads", icon: <PhoneCall size={20} />, label: "Leads" },
 
         
         // { to: "/admin/orders", icon: <Briefcase size={20} />, label: "Orders" },

--- a/frontend/src/pages/admin/lead/LeadListPage.jsx
+++ b/frontend/src/pages/admin/lead/LeadListPage.jsx
@@ -1,0 +1,107 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useAdminAuth } from '../../../context/AdminAuthContext';
+import { getAllLeads } from '../../../services/leadService';
+import { Eye, AlertCircle } from 'lucide-react';
+
+const statusColors = {
+    new: 'bg-gray-100 text-gray-800',
+    contacted: 'bg-blue-100 text-blue-800',
+    in_progress: 'bg-yellow-100 text-yellow-800',
+    closed: 'bg-green-100 text-green-800',
+};
+
+const LeadListPage = () => {
+    const { token } = useAdminAuth();
+    const [leads, setLeads] = useState([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    const fetchLeads = useCallback(async () => {
+        if (!token) return;
+        setIsLoading(true);
+        setError(null);
+        try {
+            const data = await getAllLeads(token);
+            setLeads(data);
+        } catch (err) {
+            setError(err.message || 'Failed to fetch leads.');
+        } finally {
+            setIsLoading(false);
+        }
+    }, [token]);
+
+    useEffect(() => {
+        fetchLeads();
+    }, [fetchLeads]);
+
+    if (isLoading) {
+        return (
+            <div className="flex items-center justify-center h-64">
+                <svg className="w-10 h-10 mr-3 -ml-1 text-indigo-600 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                </svg>
+                <p className="text-gray-700">Loading leads...</p>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="p-6 text-center text-red-600 bg-red-100 border border-red-300 rounded-md">
+                <AlertCircle size={48} className="mx-auto mb-2 text-red-500" />
+                <p className="text-xl font-semibold">Error loading leads</p>
+                <p>{error}</p>
+                <button onClick={fetchLeads} className="px-4 py-2 mt-4 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                    Try Again
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <div className="container px-4 py-8 mx-auto">
+            <h1 className="mb-6 text-2xl font-semibold text-gray-800">Leads</h1>
+            <div className="overflow-x-auto bg-white rounded-lg shadow">
+                <table className="min-w-full divide-y divide-gray-200">
+                    <thead className="bg-gray-50">
+                        <tr>
+                            <th className="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase">Name</th>
+                            <th className="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase">Mobile</th>
+                            <th className="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase">Status</th>
+                            <th className="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase">Created</th>
+                            <th className="px-6 py-3 text-xs font-medium tracking-wider text-right text-gray-500 uppercase">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody className="bg-white divide-y divide-gray-200">
+                        {leads.length > 0 ? (
+                            leads.map((lead) => (
+                                <tr key={lead._id} className="hover:bg-gray-50">
+                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{lead.fullName}</td>
+                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{lead.mobileNumber}</td>
+                                    <td className="px-6 py-4 whitespace-nowrap">
+                                        <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${statusColors[lead.status] || 'bg-gray-100 text-gray-800'}`}>
+                                            {lead.status.replace('_', ' ')}
+                                        </span>
+                                    </td>
+                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{new Date(lead.createdAt).toLocaleDateString()}</td>
+                                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-right">
+                                        <Link to={`/admin/leads/${lead._id}`} className="text-indigo-600 hover:text-indigo-900"><Eye size={18} /></Link>
+                                    </td>
+                                </tr>
+                            ))
+                        ) : (
+                            <tr>
+                                <td colSpan="5" className="px-6 py-4 text-sm text-center text-gray-500">No leads found.</td>
+                            </tr>
+                        )}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    );
+};
+
+export default LeadListPage;
+

--- a/frontend/src/pages/admin/lead/ViewLeadPage.jsx
+++ b/frontend/src/pages/admin/lead/ViewLeadPage.jsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useAdminAuth } from '../../../context/AdminAuthContext';
+import { getLeadById, updateLead } from '../../../services/leadService';
+
+const statusOptions = [
+    { value: 'new', label: 'New' },
+    { value: 'contacted', label: 'Contacted' },
+    { value: 'in_progress', label: 'In Progress' },
+    { value: 'closed', label: 'Closed' },
+];
+
+const ViewLeadPage = () => {
+    const { leadId } = useParams();
+    const { token } = useAdminAuth();
+    const [lead, setLead] = useState(null);
+    const [formData, setFormData] = useState({ status: 'new', notes: '' });
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState(null);
+    const [success, setSuccess] = useState('');
+
+    useEffect(() => {
+        const fetchLead = async () => {
+            if (!token) return;
+            setLoading(true);
+            setError(null);
+            try {
+                const data = await getLeadById(leadId, token);
+                setLead(data);
+                setFormData({ status: data.status || 'new', notes: data.notes || '' });
+            } catch (err) {
+                setError(err.message || 'Failed to load lead.');
+            } finally {
+                setLoading(false);
+            }
+        };
+        fetchLead();
+    }, [leadId, token]);
+
+    const handleChange = (e) => {
+        const { name, value } = e.target;
+        setFormData((prev) => ({ ...prev, [name]: value }));
+    };
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setSaving(true);
+        setError(null);
+        setSuccess('');
+        try {
+            const updated = await updateLead(leadId, formData, token);
+            setLead(updated);
+            setSuccess('Lead updated successfully.');
+        } catch (err) {
+            setError(err.message || 'Failed to update lead.');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center h-64">
+                <svg className="w-10 h-10 mr-3 -ml-1 text-indigo-600 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                </svg>
+                <p className="text-gray-700">Loading lead...</p>
+            </div>
+        );
+    }
+
+    if (error && !lead) {
+        return (
+            <div className="p-6 text-center text-red-600 bg-red-100 border border-red-300 rounded-md">
+                <p className="text-xl font-semibold">{error}</p>
+            </div>
+        );
+    }
+
+    if (!lead) return null;
+
+    return (
+        <div className="max-w-2xl p-6 mx-auto bg-white rounded-lg shadow">
+            <h1 className="mb-4 text-2xl font-semibold text-gray-800">Lead Details</h1>
+
+            <div className="mb-4">
+                <p><strong>Name:</strong> {lead.fullName}</p>
+                <p><strong>Mobile:</strong> {lead.mobileNumber}</p>
+                {lead.location && <p><strong>Location:</strong> {lead.location}</p>}
+                {lead.requirementDescription && <p><strong>Requirement:</strong> {lead.requirementDescription}</p>}
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                    <label htmlFor="status" className="block mb-1 text-sm font-medium text-gray-700">Status</label>
+                    <select
+                        id="status"
+                        name="status"
+                        value={formData.status}
+                        onChange={handleChange}
+                        className="w-full border border-gray-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500"
+                    >
+                        {statusOptions.map(opt => (
+                            <option key={opt.value} value={opt.value}>{opt.label}</option>
+                        ))}
+                    </select>
+                </div>
+
+                <div>
+                    <label htmlFor="notes" className="block mb-1 text-sm font-medium text-gray-700">Notes</label>
+                    <textarea
+                        id="notes"
+                        name="notes"
+                        rows="4"
+                        value={formData.notes}
+                        onChange={handleChange}
+                        className="w-full border border-gray-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500"
+                    ></textarea>
+                </div>
+
+                {error && <p className="text-sm text-red-600">{error}</p>}
+                {success && <p className="text-sm text-green-600">{success}</p>}
+
+                <button
+                    type="submit"
+                    disabled={saving}
+                    className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded hover:bg-indigo-700 disabled:opacity-50"
+                >
+                    {saving ? 'Saving...' : 'Save Changes'}
+                </button>
+            </form>
+        </div>
+    );
+};
+
+export default ViewLeadPage;
+

--- a/frontend/src/services/leadService.js
+++ b/frontend/src/services/leadService.js
@@ -1,0 +1,75 @@
+const API_BASE_URL = `${process.env.REACT_APP_API_URL}/api/admin`;
+
+const safeGetItem = (key) => {
+    try {
+        return localStorage.getItem(key);
+    } catch (error) {
+        console.warn(`Could not access localStorage to get item '${key}':`, error);
+        return null;
+    }
+};
+
+async function fetchAdminApi(endpoint, options = {}) {
+    const { token, ...restOptions } = options;
+    const headers = {
+        'Content-Type': 'application/json',
+        ...restOptions.headers,
+    };
+
+    const adminToken = token || safeGetItem('adminToken');
+    if (adminToken) {
+        headers['Authorization'] = `Bearer ${adminToken}`;
+    } else {
+        throw new Error('Admin authentication required.');
+    }
+
+    const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+        ...restOptions,
+        headers,
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+        const errorMessage = data.message || `HTTP error! status: ${response.status}`;
+        const error = new Error(errorMessage);
+        error.data = data;
+        error.status = response.status;
+        throw error;
+    }
+    return data;
+}
+
+export const getAllLeads = async (token) => {
+    try {
+        const data = await fetchAdminApi('/leads', { method: 'GET', token });
+        return data.data || [];
+    } catch (error) {
+        console.error('Get all leads failed:', error);
+        throw error;
+    }
+};
+
+export const getLeadById = async (leadId, token) => {
+    try {
+        const data = await fetchAdminApi(`/leads/${leadId}`, { method: 'GET', token });
+        return data.data;
+    } catch (error) {
+        console.error(`Get lead by ID (${leadId}) failed:`, error);
+        throw error;
+    }
+};
+
+export const updateLead = async (leadId, leadData, token) => {
+    try {
+        const data = await fetchAdminApi(`/leads/${leadId}`, {
+            method: 'PUT',
+            body: JSON.stringify(leadData),
+            token,
+        });
+        return data.data;
+    } catch (error) {
+        console.error(`Update lead (${leadId}) failed:`, error);
+        throw error;
+    }
+};
+


### PR DESCRIPTION
## Summary
- add lead service for admin API interactions
- list and edit leads from new admin pages
- link leads pages in admin sidebar and routing

## Testing
- `npm test` *(fails: Cannot find module 'react-router-dom' from 'src/App.jsx')*

------
https://chatgpt.com/codex/tasks/task_e_68a08ddbd5dc832bbfce4e3f3ae3e1cf