### PR TITLE
Improve login redirect and remove wishlist

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -3,7 +3,7 @@ import { NavLink, Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { useCart } from '../context/CartContext';
 import { useSite } from '../context/SiteContext';
-import { ShoppingCart, User, Heart, Search, Menu, X, Sparkles } from 'lucide-react';
+import { ShoppingCart, User, Search, Menu, X, Sparkles } from 'lucide-react';
 import Logo from './Logo';
 
 const Navbar = () => {
@@ -91,17 +91,11 @@ const Navbar = () => {
 
                     {/* Action Buttons */}
                     <div className="flex gap-3">
-                        {/* Wishlist Button */}
-                        <button className="relative flex items-center justify-center w-12 h-12 bg-surface hover:bg-primary/10 text-muted hover:text-primary rounded-2xl transition-all duration-300 hover:scale-105 border border-border hover:border-primary/20 shadow-sm hover:shadow-md group">
-                            <Heart size={20} className="transition-transform duration-300 group-hover:scale-110" />
-                            <div className="absolute -top-1 -right-1 w-3 h-3 bg-error rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-                        </button>
-
                         {/* Cart Button */}
-                        <Link 
-                            to="/cart" 
-                            className="relative flex items-center justify-center w-12 h-12 bg-primary hover:bg-primary-hover text-white rounded-2xl transition-all duration-300 hover:scale-105 shadow-lg hover:shadow-xl group"
-                        >
+                            <Link
+                                to="/cart"
+                                className="relative flex items-center justify-center w-12 h-12 bg-primary hover:bg-primary-hover text-white rounded-2xl transition-all duration-300 hover:scale-105 shadow-lg hover:shadow-xl group"
+                            >
                             <ShoppingCart size={20} className="transition-transform duration-300 group-hover:scale-110" />
                             {cartCount > 0 && (
                                 <span className="absolute -top-2 -right-2 flex items-center justify-center min-w-[20px] h-5 px-1 text-xs font-bold text-white bg-error rounded-full animate-bounce-in border-2 border-surface">
@@ -111,8 +105,8 @@ const Navbar = () => {
                         </Link>
 
                         {/* User Button */}
-                        <Link 
-                            to={isAuthenticated ? "/account/dashboard" : "/login"} 
+                        <Link
+                            to={isAuthenticated ? "/account/dashboard" : "/login"}
                             className="hidden sm:flex items-center justify-center w-12 h-12 bg-surface hover:bg-primary/10 text-muted hover:text-primary rounded-2xl transition-all duration-300 hover:scale-105 border border-border hover:border-primary/20 shadow-sm hover:shadow-md group"
                         >
                             <User size={20} className="transition-transform duration-300 group-hover:scale-110" />
@@ -207,10 +201,6 @@ const Navbar = () => {
                                     <User size={18} />
                                     <span>{isAuthenticated ? 'Account' : 'Login'}</span>
                                 </Link>
-                                <button className="flex items-center justify-center gap-2 py-3 px-4 bg-background text-text rounded-2xl font-semibold border border-border transition-all duration-300 hover:bg-border/20">
-                                    <Heart size={18} />
-                                    <span>Wishlist</span>
-                                </button>
                             </div>
                         </div>
                     </div>

--- a/frontend/src/components/ProductCard.jsx
+++ b/frontend/src/components/ProductCard.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Star, Heart, ShoppingCart } from 'lucide-react';
+import { Star, ShoppingCart } from 'lucide-react';
 
 const ProductCard = ({ product }) => {
     // Basic validation: if no product or no variants, don't render.
@@ -42,10 +42,7 @@ const ProductCard = ({ product }) => {
                     <div className="absolute inset-0 bg-gradient-to-t from-black/20 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                     
                     {/* Floating action buttons */}
-                    <div className="absolute top-4 right-4 flex flex-col gap-2 opacity-0 group-hover:opacity-100 transition-all duration-300 transform translate-x-4 group-hover:translate-x-0">
-                        <button className="flex items-center justify-center w-10 h-10 bg-surface/90 backdrop-blur-sm hover:bg-primary hover:text-white text-text rounded-full shadow-lg transition-all duration-300 hover:scale-110">
-                            <Heart size={18} />
-                        </button>
+                    <div className="absolute top-4 right-4 opacity-0 group-hover:opacity-100 transition-all duration-300 transform translate-x-4 group-hover:translate-x-0">
                         <button className="flex items-center justify-center w-10 h-10 bg-surface/90 backdrop-blur-sm hover:bg-primary hover:text-white text-text rounded-full shadow-lg transition-all duration-300 hover:scale-110">
                             <ShoppingCart size={18} />
                         </button>

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { loginUser } from '../services/authService';
 import { AlertTriangle, LogIn } from 'lucide-react';
@@ -13,8 +13,8 @@ const Login = () => {
     
     const { login, isAuthenticated } = useAuth();
     const navigate = useNavigate();
-    const [searchParams] = useSearchParams();
-    const redirectPath = searchParams.get('redirect') || '/dashboard';
+    const location = useLocation();
+    const redirectPath = location.state?.from?.pathname || '/';
 
     const handleSubmit = async (e) => {
         e.preventDefault();
@@ -33,7 +33,7 @@ const Login = () => {
             // Pass the entire response object to the context's login function
             login(response);
 
-            navigate(redirectPath);
+            navigate(redirectPath, { replace: true });
         } catch (err) {
             setError(err.message || 'Login failed. Please check your credentials.');
         } finally {
@@ -42,7 +42,7 @@ const Login = () => {
     };
 
     if (isAuthenticated) {
-        navigate(redirectPath);
+        navigate(redirectPath, { replace: true });
         return null;
     }
 

--- a/frontend/src/pages/ProductDetailPage.jsx
+++ b/frontend/src/pages/ProductDetailPage.jsx
@@ -449,9 +449,6 @@ const ProductDetailPage = () => {
                             <button onClick={handleAddToCart} disabled={isAdding || stock === 0} className="flex items-center justify-center w-full px-8 py-3 mt-6 text-base font-medium text-black bg-yellow-400 border border-transparent rounded-full hover:bg-yellow-500 disabled:bg-gray-300 disabled:cursor-not-allowed">
                                 {isAdding ? "Adding..." : "Add to Cart"}
                             </button>
-                            <button disabled={stock === 0} className="flex items-center justify-center w-full px-8 py-3 mt-3 text-base font-medium text-black bg-orange-400 border border-transparent rounded-full hover:bg-orange-500 disabled:bg-gray-300 disabled:cursor-not-allowed">
-                                Buy Now
-                            </button>
                             <div className="mt-4 space-y-2 text-sm text-gray-600">
                                 <div className="flex items-center"><RefreshCw size={16} className="mr-2" /> <span>7 days Replacement</span></div>
                                 <div className="flex items-center"><Truck size={16} className="mr-2" /> <span>Buildora Delivered</span></div>


### PR DESCRIPTION
## Summary
- redirect to originating page after login
- drop wishlist UI elements
- remove Buy Now option from product details

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.jsx')*


------
https://chatgpt.com/codex/tasks/task_e_68a8f04ec950832bbb542245ffd3fe9a